### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4235,7 +4235,7 @@ ${css}
 
       if (this.hasAttribute("block")) {
         // normalize the tab indents
-        content = content.replace(/\n/, "");
+        content = content.replace(/\n/g, "");
         const tabs = content.match(/\s*/);
         content = content.replace(new RegExp("\n" + tabs, "g"), "\n");
         content = content.trim();


### PR DESCRIPTION
Potential fix for [https://github.com/abhilesh/al-folio/security/code-scanning/7](https://github.com/abhilesh/al-folio/security/code-scanning/7)

To fix the problem, we need to ensure that all occurrences of the newline character are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace the string literal `"\n"` with the regular expression `/\n/g`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
