### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[^<]*?>)(?:<!\[CDATA\[[^<]*?\]\]>\s*|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/abhilesh/al-folio/security/code-scanning/3](https://github.com/abhilesh/al-folio/security/code-scanning/3)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should replace `[\s\S]*?` with a more precise pattern that avoids matching in multiple ways. One approach is to use a negated character class that matches any character except the closing tag sequence.

- Replace `[\s\S]*?` with `[^<]*?` to match any character except the opening angle bracket `<`, which is a more precise and less ambiguous pattern.
- This change should be made in the regular expression on line 3173 of the file `assets/js/distillpub/template.v2.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
